### PR TITLE
Move general things to setup in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,11 +35,9 @@ Please use the `issue tracker
 contributing and reporting.
 
 
-Quickstart on Linux
-===================
+Setup
+=====
 
-Prepare Docker
---------------
 1. `Install Docker <https://docs.docker.com/engine/installation/>`__
 
 2. Verify Docker is working::
@@ -51,9 +49,10 @@ Prepare Docker
       Hello from Docker.
       This message shows that ...
 
-3. Download the image::
+3. Download the Docker image::
 
       docker pull t3docs/render-documentation
+
 
 4. Verify::
 
@@ -68,7 +67,22 @@ Prepare Docker
 
       ... did you mean 'dockrun_t3rdf makehtml'?
 
-5. Define some shell commands::
+5. Go to your documentation project
+
+   For example, clone an existing manual::
+
+      git clone https://github.com/TYPO3-Documentation/TYPO3CMS-Tutorial-GettingStarted.git
+      cd TYPO3CMS-Tutorial-GettingStarted
+
+   Whatever documentation project you use, you should be in the parent directory
+   of the Documentation directory when you run the following commands.
+
+
+Quickstart on Linux
+===================
+
+
+1. Define some shell commands::
 
       # just show
       docker run --rm t3docs/render-documentation show-shell-commands
@@ -83,30 +97,10 @@ Prepare Docker
            source tempfile.sh
            rm tempfile.sh
 
-      # Verify there now is a command to 'TYPO3 render documentation full'::
+      # Verify executing the command dockrun_t3rdf::
 
            dockrun_t3rdf --help
 
-
-Render your documentation
--------------------------
-1. Go to the **start folder** of your PROJECT. It should have a subfolder
-   Documentation.
-
-   You can use this `starter project
-   <https://github.com/T3DocumentationStarter/Public-Info-000/archive/master.zip>`__
-   as an example::
-
-      # download
-      wget https://github.com/T3DocumentationStarter/Public-Info-000/archive/master.zip
-
-      # unpack
-      unzip master.zip
-
-      # DO NOT go to the subfolder Public-Info-000-master/Documentation !!!
-
-      # go to the **start folder** of the PROJECT
-      cd Public-Info-000-master
 
 
 2. Do the rendering

--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ Quickstart on Linux
            source tempfile.sh
            rm tempfile.sh
 
-      # Verify executing the command dockrun_t3rdf::
+      # Verify that command dockrun_t3rdf is now available::
 
            dockrun_t3rdf --help
 


### PR DESCRIPTION
Docker install, docker pull and setting up a documentation project is not platform specific. Move this from Linux Quickstart to general *setup* section.