### PR TITLE
Feature/update to html only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *GENERATED*
 *NOT_VERSIONED*
+/ALL-for-build/t3SphinxThemeRtd/

--- a/ALL-for-build/Menu/mainmenu.sh
+++ b/ALL-for-build/Menu/mainmenu.sh
@@ -80,11 +80,12 @@ function mm-tct() {
 # Ideally, we should use variables RESULT, PROJECT and VERSION but
 # these are not available here
 function tell-about-results() {
-local exitstatus=$1
-local outputdir="Documentation-GENERATED-temp/Result/project/0.0.0"
-if [ $exitstatus -eq 0 ]
-then
-   cat <<EOT
+    local exitstatus=$1
+    local outputdir="Documentation-GENERATED-temp/Result/project/0.0.0"
+
+    if [ $exitstatus -eq 0 ]
+    then
+        cat <<EOT
 
 Final exit status: 0 (completed)
 
@@ -105,100 +106,102 @@ Find the (possible) results. For example:
    ./$outputdir/_buildinfo/warnings.txt
 EOT
 
-# environment variable HOST_CWD must be defined: current working directory on host
-# platform
-if [ ! -z "${HOST_CWD}" ];then
-   echo " "
-   echo "Usually, you can open the results using these URLS:"
-   echo "  - html: file://${HOST_CWD}/$outputdir/Index.html"
-   echo "  - warnings: file://${HOST_CWD}/$outputdir/_buildinfo/warnings.txt"
-else
-   echo " "
-   echo "Make environment variable HOST_CWD (current working directory on host) available to see full paths of results!"
-fi
+        # environment variable HOST_CWD must be defined: current working directory on host
+        # platform
+        if [ ! -z "${HOST_CWD}" ];then
+            echo " "
+            echo "Usually, you can open the results using these URLS:"
+            echo "  - html: file://${HOST_CWD}/$outputdir/Index.html"
+            echo "  - warnings: file://${HOST_CWD}/$outputdir/_buildinfo/warnings.txt"
+            else
+            echo " "
+            echo "Make environment variable HOST_CWD (current working directory on host) available to see full paths of results!"
+        fi
 
-echo " "
-echo "=================================================="
-echo " "
-echo "More information: https://github.com/t3docs/docker-render-documentation/blob/master/README.rst"
+        echo " "
+        echo "=================================================="
+        echo " "
+        echo "More information: https://github.com/t3docs/docker-render-documentation/blob/master/README.rst"
 
-else
-   cat <<EOT
+    else
+        cat <<EOT
 
-Final exit status: $exitstatus (aborted)
+    Final exit status: $exitstatus (aborted)
 
-Check for results:
-   ./Documentation-GENERATED-temp/
+    Check for results:
+    ./Documentation-GENERATED-temp/
 EOT
-fi
+    fi
 }
 
 function mm-makeall() {
    local cmd
    shift
 
-# make sure nothing is left over from previous run
-if [[ -f /tmp/RenderDocumentation/Todo/ALL.source-me.sh ]]
-then
-   rm -f /tmp/RenderDocumentation/Todo/ALL.source-me.sh
-fi
-cmd="tct --cfg-file=/ALL/Rundir/tctconfig.cfg -v"
-cmd="$cmd run RenderDocumentation -c makedir /ALL/Makedir"
-cmd="$cmd -c make_latex 1 -c make_package 1 -c make_pdf 1 -c make_singlehtml 1"
-cmd="$cmd $@"
-eval $cmd
+    # make sure nothing is left over from previous run
+    if [[ -f /tmp/RenderDocumentation/Todo/ALL.source-me.sh ]]
+    then
+        rm -f /tmp/RenderDocumentation/Todo/ALL.source-me.sh
+    fi
 
-local exitstatus=$?
+    cmd="tct --cfg-file=/ALL/Rundir/tctconfig.cfg -v"
+    cmd="$cmd run RenderDocumentation -c makedir /ALL/Makedir"
+    cmd="$cmd -c make_latex 1 -c make_package 1 -c make_pdf 1 -c make_singlehtml 1"
+    cmd="$cmd $@"
+    eval $cmd
 
-# do localizations
-if [[ -f /tmp/RenderDocumentation/Todo/ALL.source-me.sh ]]
-then
-   source /tmp/RenderDocumentation/Todo/ALL.source-me.sh
-fi
+    local exitstatus=$?
 
-if [[ ( $exitstatus -eq 0 ) \
-   && ( -d /ALL/dummy_webroot/typo3cms/drafts/project ) \
-   && ( -d /RESULT ) ]]
-then
-rsync -a /ALL/dummy_webroot/typo3cms/drafts/project /RESULT/Result/ --delete
-exitstatus=$?
-fi
+    # do localizations
+    if [[ -f /tmp/RenderDocumentation/Todo/ALL.source-me.sh ]]
+    then
+        source /tmp/RenderDocumentation/Todo/ALL.source-me.sh
+    fi
 
-tell-about-results $exitstatus
+    if [[ ( $exitstatus -eq 0 ) \
+        && ( -d /ALL/dummy_webroot/typo3cms/drafts/project ) \
+        && ( -d /RESULT ) ]]
+    then
+        rsync -a /ALL/dummy_webroot/typo3cms/drafts/project /RESULT/Result/ --delete
+        exitstatus=$?
+    fi
+
+    tell-about-results $exitstatus
 }
 
 function mm-makehtml() {
    local cmd
    shift
 
-# make sure nothing is left over from previous run
-if [[ -f /tmp/RenderDocumentation/Todo/ALL.source-me.sh ]]
-then
-   rm -f /tmp/RenderDocumentation/Todo/ALL.source-me.sh
-fi
-cmd="tct --cfg-file=/ALL/Rundir/tctconfig.cfg -v"
-cmd="$cmd run RenderDocumentation -c makedir /ALL/Makedir"
-cmd="$cmd -c make_latex 0 -c make_package 0 -c make_pdf 0 -c make_singlehtml 0"
-cmd="$cmd $@"
-eval $cmd
+    # make sure nothing is left over from previous run
+    if [[ -f /tmp/RenderDocumentation/Todo/ALL.source-me.sh ]]
+    then
+        rm -f /tmp/RenderDocumentation/Todo/ALL.source-me.sh
+    fi
 
-local exitstatus=$?
+    cmd="tct --cfg-file=/ALL/Rundir/tctconfig.cfg -v"
+    cmd="$cmd run RenderDocumentation -c makedir /ALL/Makedir"
+    cmd="$cmd -c make_latex 0 -c make_package 0 -c make_pdf 0 -c make_singlehtml 0"
+    cmd="$cmd $@"
+    eval $cmd
 
-# do localizations
-if [[ -f /tmp/RenderDocumentation/Todo/ALL.source-me.sh ]]
-then
-   source /tmp/RenderDocumentation/Todo/ALL.source-me.sh
-fi
+    local exitstatus=$?
 
-if [[ ( $exitstatus -eq 0 ) \
-   && ( -d /ALL/dummy_webroot/typo3cms/drafts/project ) \
-   && ( -d /RESULT ) ]]
-then
-rsync -a /ALL/dummy_webroot/typo3cms/drafts/project /RESULT/Result/ --delete
-exitstatus=$?
-fi
+    # do localizations
+    if [[ -f /tmp/RenderDocumentation/Todo/ALL.source-me.sh ]]
+    then
+        source /tmp/RenderDocumentation/Todo/ALL.source-me.sh
+    fi
 
-tell-about-results $exitstatus
+    if [[ ( $exitstatus -eq 0 ) \
+        && ( -d /ALL/dummy_webroot/typo3cms/drafts/project ) \
+        && ( -d /RESULT ) ]]
+    then
+        rsync -a /ALL/dummy_webroot/typo3cms/drafts/project /RESULT/Result/ --delete
+        exitstatus=$?
+    fi
+
+    tell-about-results $exitstatus
 }
 
 case "$1" in

--- a/ALL-for-build/Menu/mainmenu.sh
+++ b/ALL-for-build/Menu/mainmenu.sh
@@ -99,9 +99,6 @@ Find the (possible) results. For example:
   singlehtml:
    ./$outputdir/singlehtml/Index.html
 
-  pdf:
-   ./$outputdir/_pdf/
-
   warnings:
    ./$outputdir/_buildinfo/warnings.txt
 EOT
@@ -146,7 +143,7 @@ function mm-makeall() {
 
     cmd="tct --cfg-file=/ALL/Rundir/tctconfig.cfg -v"
     cmd="$cmd run RenderDocumentation -c makedir /ALL/Makedir"
-    cmd="$cmd -c make_latex 1 -c make_package 1 -c make_pdf 1 -c make_singlehtml 1"
+    cmd="$cmd -c make_latex 0 -c make_package 1 -c make_pdf 0 -c make_singlehtml 1"
     cmd="$cmd $@"
     eval $cmd
 

--- a/ALL-for-build/Menu/show-shell-commands.sh
+++ b/ALL-for-build/Menu/show-shell-commands.sh
@@ -6,8 +6,8 @@ source /ALL/Downloads/envvars.sh
 #1
 VERSION=${VERSION:-"v2.0.0-full"}
 DOCKRUN_PREFIX=${DOCKRUN_PREFIX:-"dockrun_"}
-OUR_IMAGE_SHORT=${OUR_IMAGE_SHORT:-t3rdf}
-OUR_IMAGE_SLOGAN=${OUR_IMAGE_SLOGAN:-"t3rdf - TYPO3 render documentation full"}
+OUR_IMAGE_SHORT=${OUR_IMAGE_SHORT:-t3rd}
+OUR_IMAGE_SLOGAN=${OUR_IMAGE_SLOGAN:-"t3rd - TYPO3 render documentation full"}
 #2
 OUR_IMAGE_TAG=${OUR_IMAGE_TAG:-"$VERSION"}
 #3
@@ -21,7 +21,7 @@ cat <<EOT
 # ATTENTION:
 #     No whitespace between '<('
 
-# the usual worker command like 'dockrun_t3rdf'
+# the usual worker command like 'dockrun_t3rd'
 function ${DOCKRUN_PREFIX}${OUR_IMAGE_SHORT} () {
 
 # Environment variables the USER may find important (on the host!),

--- a/ALL-for-build/Menu/show-shell-commands.sh
+++ b/ALL-for-build/Menu/show-shell-commands.sh
@@ -4,7 +4,7 @@ source /ALL/Downloads/envvars.sh
 
 # provide defaults
 #1
-VERSION=${VERSION:-"v1.6.11-full"}
+VERSION=${VERSION:-"v2.0.0-full"}
 DOCKRUN_PREFIX=${DOCKRUN_PREFIX:-"dockrun_"}
 OUR_IMAGE_SHORT=${OUR_IMAGE_SHORT:-t3rdf}
 OUR_IMAGE_SLOGAN=${OUR_IMAGE_SLOGAN:-"t3rdf - TYPO3 render documentation full"}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -56,7 +56,7 @@ If your documentation project does not have a docker-compose.yml file for docker
 you can easily add one, see
 `Quickstart with Docker Compose <https://github.com/t3docs/docker-render-documentation#quickstart-with-docker-compose>`__.
 
-If you use the workflow with source / run and `dockrun_t3rdf makehtml`, then once you
+If you use the workflow with source / run and `dockrun_t3rd makehtml`, then once you
 generated the documentation, you can
 modify the file `Documentation-GENERATED-temp/last-docker-run-command-GENERATED.sh`
 and replace the name / version of the Docker image with your locally built one and execute

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -61,3 +61,25 @@ generated the documentation, you can
 modify the file `Documentation-GENERATED-temp/last-docker-run-command-GENERATED.sh`
 and replace the name / version of the Docker image with your locally built one and execute
 this file to render the documentation with your locally built Docker image.
+
+Use local version of Theme
+==========================
+
+While working on https://github.com/TYPO3-Documentation/t3SphinxThemeRtd you need to
+test those changes. The easiest way is to build the Docker container using the local
+version of the theme. Therefore follow these steps:
+
+#. Copy sub folder `t3SphinxThemeRtd` from the theme to `ALL-for-build/`.
+
+#. Adjust `Dockerfile` to use the local version by changing line::
+
+      && pip install https://github.com/TYPO3-Documentation/t3SphinxThemeRtd/archive/${THEME_VERSION}.zip \
+
+   to::
+
+      && pip install ../t3SphinxThemeRtd/ \
+
+#. Follow above steps to build Docker container.
+
+The generated container should now contain the local theme version instead of the
+official version, which would be downloaded.

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,14 @@
 
 Changelog.txt
 
+v2.0.0
+   2019-03-11
+   - Remove output other then HTML
+     Therefore only a single tag is provided, which is the version. There is
+     no longer a full or html.
+   - Strip off dependencies to make building of container faster, and to lower
+     the file site of resulting container.
+
 v1.6.11-full
    2018-05-23
    - typoscript syntax highlighter should now always succeed

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ ARG OUR_IMAGE_TAG=${OUR_IMAGE_VERSION}
 ARG DEBIAN_FRONTEND=noninteractive
 ARG DOCKRUN_PREFIX="dockrun_"
 ARG hack_OUR_IMAGE="t3docs/render-documentation:${OUR_IMAGE_TAG}"
-ARG hack_OUR_IMAGE_SHORT="t3rdf"
-ARG OUR_IMAGE_SLOGAN="t3rdf - TYPO3 render documentation full"
+ARG hack_OUR_IMAGE_SHORT="t3rd"
+ARG OUR_IMAGE_SLOGAN="t3rd - TYPO3 render documentation"
 
 ENV \
    HOME="/ALL/userhome" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM python:2
 # Rename example:
 #   docker tag t3docs/render-documentation[:tag1] t3docs/render-documentation[:tag2]
 
-ARG OUR_IMAGE_VERSION=v1.6.11-full
+ARG OUR_IMAGE_VERSION=v2.0.0
 ARG OUR_IMAGE_TAG=${OUR_IMAGE_VERSION}
 # flag for apt-get - affects only build time
 ARG DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,8 @@ RUN \
    && COMMENT "always:" \
    && apt-get install -yq --no-install-recommends \
       pandoc \
-      unzip \
       rsync \
+      unzip \
       zip \
    \
    && COMMENT "Try extra cleaning besides /etc/apt/apt.conf.d/docker-clean" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,9 +109,10 @@ RUN \
            --quiet --output-document /ALL/Makedir/_htaccess \
    && wget https://github.com/etobi/Typo3ExtensionUtils/raw/master/bin/t3xutils.phar \
            --quiet --output-document /usr/local/bin/t3xutils.phar \
-   && chmod +x /usr/local/bin/t3xutils.phar \
-   \
-   && COMMENT "Install Python packages" \
+   && chmod +x /usr/local/bin/t3xutils.phar
+
+RUN \
+   COMMENT "Install Python packages" \
    && pip install --upgrade pip \
    && pip install https://github.com/TYPO3-Documentation/t3SphinxThemeRtd/archive/${THEME_VERSION}.zip \
    && find /usr/local/lib/python2.7/site-packages/t3SphinxThemeRtd/ -exec touch --no-create --time=mtime --date="$(date --rfc-2822 --date=@$THEME_MTIME)" {} \; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,17 +73,11 @@ RUN \
    \
    && COMMENT "Install system packages" \
    && apt-get update \
-   \
-   && COMMENT "for ubuntu:18.04: (unfinished)" \
-   && apt-get install --dry-run -yq --no-install-recommends \
-      wget \
-      python \
-      \
-   && COMMENT "always:" \
    && apt-get install -yq --no-install-recommends \
       pandoc \
       rsync \
       unzip \
+      wget \
       zip \
    \
    && COMMENT "Try extra cleaning besides /etc/apt/apt.conf.d/docker-clean" \
@@ -131,11 +125,6 @@ RUN COMMENT "Provide the toolchain" \
    && unzip /ALL/Downloads/Toolchain_RenderDocumentation.zip -d /ALL/Toolchains \
    && mv /ALL/Toolchains/${TOOLCHAIN_UNPACKED} /ALL/Toolchains/RenderDocumentation \
    && rm /ALL/Downloads/Toolchain_RenderDocumentation.zip \
-   \
-   && COMMENT "Download latex files" \
-   && wget https://github.com/TYPO3-Documentation/latex.typo3/archive/v1.1.0.zip -qO /tmp/latex.typo3-v1.1.0.zip \
-   && unzip /tmp/latex.typo3-v1.1.0.zip -d /tmp \
-   && mv /tmp/latex.typo3-1.1.0 /ALL/Downloads/latex.typo3 \
    \
    && COMMENT "Final cleanup" \
    && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,17 +18,6 @@ FROM python:2
 #             echo "There was an error building the image."
 #             exit 1
 #          }
-# Use:
-#    docker run --rm t3docs/render-documentation[:tag]
-#    source <(docker run --rm t3docs/render-documentation[:tag] show-shell-commands)
-#    dockrun_t3rdf
-#    dockrun_t3rdf makehtml
-# or
-#    ddockrun_t3rdf
-#    ddockrun_t3rdf makeall
-#
-# Rename example:
-#   docker tag t3docs/render-documentation[:tag1] t3docs/render-documentation[:tag2]
 
 ARG OUR_IMAGE_VERSION=v2.0.0
 ARG OUR_IMAGE_TAG=${OUR_IMAGE_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,7 @@
 
 # ==================================================
 # (1) results in ca. 821MB
-#FROM python:2
-
-# (2) results in ca. 2.06GB, can create latex pdf
-# FROM t3docs/python2-with-latex
-
-# (3) results in ca. 2.53 GB, can create latex pdf, can read OpenOffice
-FROM t3docs/docker-libreoffice-on-python2-with-latex
+FROM python:2
 
 # ==================================================
 
@@ -98,14 +92,9 @@ RUN \
       \
    && COMMENT "always:" \
    && apt-get install -yq --no-install-recommends \
-      less \
-      nano \
-      ncdu \
       pandoc \
-      php5-cli \
-      rsync \
-      tidy \
       unzip \
+      rsync \
       zip \
    \
    && COMMENT "Try extra cleaning besides /etc/apt/apt.conf.d/docker-clean" \
@@ -192,7 +181,6 @@ RUN COMMENT "Provide the toolchain" \
       Python packages     see requirements.txt\n\
                           Sphinx\n\
                           recommonmark           v2018-05-04\n\
-      TYPO3-Documentation typo3.latex            v1.1.0\n\
       TypoScript lexer    typoscript.py          $TYPOSCRIPT_PY_VERSION\n" | cut -b 7- > /ALL/Downloads/buildinfo.txt \
    && cat /ALL/Downloads/buildinfo.txt
 

--- a/InofficialExtras/build-the-docker-image-full-finaltest.sh
+++ b/InofficialExtras/build-the-docker-image-full-finaltest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-OUR_IMAGE_TAG=v1.6.11-full
+OUR_IMAGE_TAG=v2.0.0-full
 EXITCODE=0
 
 if ((1)); then

--- a/InofficialExtras/build-the-docker-image-full.sh
+++ b/InofficialExtras/build-the-docker-image-full.sh
@@ -7,8 +7,8 @@
 #     ./build-the-docker-image-html.sh
 # Examples:
 #     cd InofficialExtras
-#     VERSION=v1.6.11-full ./build-the-docker-image.sh
-#     VERSION=v1.6.11-full DOCKRUN_PREFIX="dockrun_" ... ./build-the-docker-image-html.sh
+#     VERSION=v2.0.0-full ./build-the-docker-image.sh
+#     VERSION=v2.0.0-full DOCKRUN_PREFIX="dockrun_" ... ./build-the-docker-image-html.sh
 
 # REMEMBER: How to find the theme mtime:
 #    cd ~/Repositories/github.com/TYPO3-Documentation/t3SphinxThemeRtd
@@ -19,7 +19,7 @@
 #
 
 # variables 1
-VERSION=${VERSION:-"v1.6.11-full"}
+VERSION=${VERSION:-"v2.0.0-full"}
 DEBIAN_FRONTEND=${DEBIAN_FRONTEND:-noninteractive}
 DOCKRUN_PREFIX=${DOCKRUN_PREFIX:-"dockrun_"}
 OUR_IMAGE_SHORT=${OUR_IMAGE_SHORT:-t3rdf}

--- a/InofficialExtras/build-the-docker-image-full.sh
+++ b/InofficialExtras/build-the-docker-image-full.sh
@@ -22,8 +22,8 @@
 VERSION=${VERSION:-"v2.0.0-full"}
 DEBIAN_FRONTEND=${DEBIAN_FRONTEND:-noninteractive}
 DOCKRUN_PREFIX=${DOCKRUN_PREFIX:-"dockrun_"}
-OUR_IMAGE_SHORT=${OUR_IMAGE_SHORT:-t3rdf}
-OUR_IMAGE_SLOGAN=${OUR_IMAGE_SLOGAN:-"t3rdf - TYPO3 render documentation full"}
+OUR_IMAGE_SHORT=${OUR_IMAGE_SHORT:-t3rd}
+OUR_IMAGE_SLOGAN=${OUR_IMAGE_SLOGAN:-"t3rd - TYPO3 render documentation full"}
 # variables 2
 OUR_IMAGE_TAG=${OUR_IMAGE_TAG:-"$VERSION"}
 # variables 3

--- a/InofficialExtras/build-the-docker-image.sh
+++ b/InofficialExtras/build-the-docker-image.sh
@@ -7,9 +7,9 @@
 #     ./build-the-docker-image.sh
 # Examples:
 #     cd InofficialExtras
-#     VERSION=v1.6.11-full ./build-the-docker-image.sh
-#     VERSION=v1.6.11-full OUR_IMAGE_TAG=latest DOCKRUN_PREFIX="dockrun_" ./build-the-docker-image.sh
-#     VERSION=v1.6.11-full DOCKRUN_PREFIX="ddockrun_" ./build-the-docker-image.sh
+#     VERSION=v2.0.0-full ./build-the-docker-image.sh
+#     VERSION=v2.0.0-full OUR_IMAGE_TAG=latest DOCKRUN_PREFIX="dockrun_" ./build-the-docker-image.sh
+#     VERSION=v2.0.0-full DOCKRUN_PREFIX="ddockrun_" ./build-the-docker-image.sh
 
 
 # How to find the theme mtime:
@@ -21,7 +21,7 @@
 #
 
 # variables 1
-VERSION=${VERSION:-"v1.6.11-dev-html"}
+VERSION=${VERSION:-"v2.0.0-dev-html"}
 DEBIAN_FRONTEND=${DEBIAN_FRONTEND:-noninteractive}
 DOCKRUN_PREFIX=${DOCKRUN_PREFIX:-"dockrun_"}
 OUR_IMAGE_SHORT=${OUR_IMAGE_SHORT:-t3rd}

--- a/InofficialExtras/ra-render-coreapi.sh
+++ b/InofficialExtras/ra-render-coreapi.sh
@@ -6,11 +6,11 @@
 # use 'build-the-docker-image.sh' first.
 
 # define shortcuts dockrun_t3rdh, dockrun_t3rdf
-# source <(docker run --rm t3docs/render-documentation:v1.6.11-dev-html show-shell-commands)
+# source <(docker run --rm t3docs/render-documentation:v2.0.0-dev-html show-shell-commands)
 source <( \
    docker run --rm \
    -v /home/marble/Repositories/github.com/t3docs/docker-render-documentation/ALL-for-build/Menu:/ALL/Menu \
-   t3docs/render-documentation:v1.6.11-full show-shell-commands \
+   t3docs/render-documentation:v2.0.0-full show-shell-commands \
    )
 
 # ##################################################

--- a/InofficialExtras/ra-render-coreapi.sh
+++ b/InofficialExtras/ra-render-coreapi.sh
@@ -5,7 +5,7 @@
 
 # use 'build-the-docker-image.sh' first.
 
-# define shortcuts dockrun_t3rdh, dockrun_t3rdf
+# define shortcuts dockrun_t3rdh, dockrun_t3rd
 # source <(docker run --rm t3docs/render-documentation:v2.0.0-dev-html show-shell-commands)
 source <( \
    docker run --rm \
@@ -60,7 +60,7 @@ popd >/dev/null
 
 # ##################################################
 
-dockrun_t3rdf makehtml
+dockrun_t3rd makehtml
 
 # ##################################################
 unset T3DOCS_DEBUG T3DOCS_DUMMY_WEBROOT T3DOCS_MAKEDIR T3DOCS_MENU

--- a/InofficialExtras/rc-render-changelog.sh
+++ b/InofficialExtras/rc-render-changelog.sh
@@ -5,7 +5,7 @@
 
 # use 'build-the-docker-image.sh' first.
 
-# define shortcut 'developer dockrun': ddockrun_t3rdf
+# define shortcut 'developer dockrun': ddockrun_t3rd
 source <(docker run --rm t3docs/render-documentation:v2.0.0-full show-shell-commands)
 
 # ##################################################
@@ -45,7 +45,7 @@ popd >/dev/null
 
 # how to add what you need:
 
-ddockrun_t3rdf makehtml
+ddockrun_t3rd makehtml
 
 #   -c make_singlehtml 1
 #   -c make_latex 1
@@ -55,7 +55,7 @@ ddockrun_t3rdf makehtml
 # ##################################################
 # how to deselect what you don't need:
 
-#ddockrun_t3rdf makeall
+#ddockrun_t3rd makeall
 
 #   -c make_latex 0 \
 #   -c make_package 0 \

--- a/InofficialExtras/rc-render-changelog.sh
+++ b/InofficialExtras/rc-render-changelog.sh
@@ -6,7 +6,7 @@
 # use 'build-the-docker-image.sh' first.
 
 # define shortcut 'developer dockrun': ddockrun_t3rdf
-source <(docker run --rm t3docs/render-documentation:v1.6.11-full show-shell-commands)
+source <(docker run --rm t3docs/render-documentation:v2.0.0-full show-shell-commands)
 
 # ##################################################
 unset T3DOCS_DEBUG T3DOCS_DUMMY_WEBROOT T3DOCS_MAKEDIR T3DOCS_MENU
@@ -76,7 +76,7 @@ docker run --rm --user=1000:1000 \
    -v /home/marble/Repositories/github.com/t3docs/docker-render-documentation/ALL-for-build/Rundir:/ALL/Rundir \
    -v /home/marble/Repositories/github.com/t3docs/VOLUMES/Toolchains:/ALL/Toolchains \
    -v /home/marble/Repositories/github.com/t3docs/VOLUMES/GENERATED/Documentation-GENERATED-temp/Cache/site-packages:/usr/local/lib/python2.7/site-packages \
-   t3docs/render-documentation:v1.6.11-full makehtml
+   t3docs/render-documentation:v2.0.0-full makehtml
 fi
 
 # ##################################################

--- a/InofficialExtras/rs-render-something.sh
+++ b/InofficialExtras/rs-render-something.sh
@@ -6,7 +6,7 @@
 # use 'build-the-docker-image.sh' first.
 
 # define shortcut 'developer dockrun': ddockrun_t3rdf
-source <(docker run --rm t3docs/render-documentation:v1.6.11-full show-shell-commands)
+source <(docker run --rm t3docs/render-documentation:v2.0.0-full show-shell-commands)
 
 # select project
 T3DOCS_PROJECT=/home/marble/Repositories/github.com/TYPO3-Documentation/TYPO3CMS-Tutorial-SitePackage
@@ -73,7 +73,7 @@ docker run --rm --user=1000:1000 \
    -v /home/marble/Repositories/github.com/t3docs/docker-render-documentation/ALL-for-build/Rundir:/ALL/Rundir \
    -v /home/marble/Repositories/github.com/t3docs/VOLUMES/Toolchains:/ALL/Toolchains \
    -v /home/marble/Repositories/github.com/t3docs/VOLUMES/GENERATED/Documentation-GENERATED-temp/Cache/site-packages:/usr/local/lib/python2.7/site-packages \
-   t3docs/render-documentation:v1.6.11-full makehtml
+   t3docs/render-documentation:v2.0.0-full makehtml
 fi
 
 # ##################################################

--- a/InofficialExtras/rs-render-something.sh
+++ b/InofficialExtras/rs-render-something.sh
@@ -5,7 +5,7 @@
 
 # use 'build-the-docker-image.sh' first.
 
-# define shortcut 'developer dockrun': ddockrun_t3rdf
+# define shortcut 'developer dockrun': ddockrun_t3rd
 source <(docker run --rm t3docs/render-documentation:v2.0.0-full show-shell-commands)
 
 # select project
@@ -37,12 +37,12 @@ T3DOCS_MAKEDIR=/home/marble/Repositories/github.com/t3docs/VOLUMES/GENERATED/tmp
 
 # ##################################################
 
-# ddockrun_t3rdf makehtml
+# ddockrun_t3rd makehtml
 
 # ##################################################
 # how to add what you need:
 
-#ddockrun_t3rdf makehtml \
+#ddockrun_t3rd makehtml \
 #   -c make_singlehtml 1
 
 #   -c make_latex 1
@@ -52,7 +52,7 @@ T3DOCS_MAKEDIR=/home/marble/Repositories/github.com/t3docs/VOLUMES/GENERATED/tmp
 # ##################################################
 # how to deselect what you don't need:
 
-ddockrun_t3rdf makeall
+ddockrun_t3rd makeall
 
 #   -c make_latex 0 \
 #   -c make_package 0 \

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Quickstart on Linux or macOS
 
 2. Render your documentation from the root folder of your project ::
 
-      dockrun_t3rdf makehtml
+      dockrun_t3rd makehtml
 
 3. open the Documentation under:
 
@@ -96,24 +96,24 @@ You can render a project that's located somewhere else. Set the environment
 variable `T3DOCS_PROJECT` accordingly::
 
    export T3DOCS_PROJECT=/abs/path/to/project
-   dockrun_t3rdf makehtml
+   dockrun_t3rd makehtml
 
 or::
 
-   T3DOCS_PROJECT=/abs/path/to/project  dockrun_t3rdf makehtml
+   T3DOCS_PROJECT=/abs/path/to/project  dockrun_t3rd makehtml
 
 Specify a result folder to send the result somewhere else. The final output
 folder `$T3DOCS_RESULT/Documentation-GENERATED-temp` will be created::
 
    export T3DOCS_RESULT=/abs/path/to/result
-   dockrun_t3rdf makehtml
+   dockrun_t3rd makehtml
 
 Specify a path to a temp folder if you want to expose all those many
 intermediate temp files for inspection. `$T3DOCS_RESULT/tmp-GENERATED-temp`
 will be used::
 
    export T3DOCS_TMP=/tmp
-   dockrun_t3rdf makehtml
+   dockrun_t3rd makehtml
 
 
 Rename to default tag 'latest'

--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,8 @@ This is the official recipe to build the Docker image
 :Docker tags:     https://hub.docker.com/r/t3docs/render-documentation/tags/
 :See also:        Toolchain 'RenderDocumentation'
                   https://github.com/marble/Toolchain_RenderDocumentation
-:Date:            2018-07-04
-:Version:         Docker image version 'latest'='v1.6.11-full', from
+:Date:            2019-03-11
+:Version:         Docker image version 'latest'='v2.0.0', from
                   repository branch 'master'
 :Capabilites:     html
 
@@ -124,9 +124,9 @@ downloaded image to 'latest' if what you downloaded was not 'latest'::
    # remove
    docker rmi t3docs/render-documentation:latest
    # pull
-   docker pull t3docs/render-documentation:v1.6.11-full
+   docker pull t3docs/render-documentation:v2.0.0
    # rename
-   docker tag t3docs/render-documentation:v1.6.11-full \
+   docker tag t3docs/render-documentation:v2.0.0
               t3docs/render-documentation:latest
    # use the generic name without tag, for example in ~/.bashrc
    source <(docker run --rm t3docs/render-documentation show-shell-commands)

--- a/README.rst
+++ b/README.rst
@@ -44,13 +44,13 @@ Quickstart on Linux or macOS
 1. Make the shellcommand available in your shell and load the container if not done already::
 
       source <(docker run --rm t3docs/render-documentation show-shell-commands)
-   
+
 2. Render your documentation from the root folder of your project ::
 
       dockrun_t3rdf makehtml
-   
+
 3. open the Documentation under:
-  
+
   "Documentation-GENERATED-temp/Result/project/0.0.0/Index.html"
 
 Quickstart on Windows

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ t3docs/render-documentation show-shell-commands` to learn about the details.
 You can render a project that's located somewhere else. Set the environment
 variable `T3DOCS_PROJECT` accordingly::
 
-   T3DOCS_PROJECT=/abs/path/to/project
+   export T3DOCS_PROJECT=/abs/path/to/project
    dockrun_t3rdf makehtml
 
 or::
@@ -105,14 +105,14 @@ or::
 Specify a result folder to send the result somewhere else. The final output
 folder `$T3DOCS_RESULT/Documentation-GENERATED-temp` will be created::
 
-   T3DOCS_RESULT=/abs/path/to/result
+   export T3DOCS_RESULT=/abs/path/to/result
    dockrun_t3rdf makehtml
 
 Specify a path to a temp folder if you want to expose all those many
 intermediate temp files for inspection. `$T3DOCS_RESULT/tmp-GENERATED-temp`
 will be used::
 
-   T3DOCS_TMP=/tmp
+   export T3DOCS_TMP=/tmp
    dockrun_t3rdf makehtml
 
 

--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,7 @@ This is the official recipe to build the Docker image
 :Date:            2018-07-04
 :Version:         Docker image version 'latest'='v1.6.11-full', from
                   repository branch 'master'
-:Capabilites:     html, singlehtml, package, latex, pdf;
-                  can read and convert ./doc/manual.sxw
+:Capabilites:     html
 
 .. contents:: Table of Contents
    :local:
@@ -86,24 +85,6 @@ Docker Compose
 Advanced
 ========
 
-Run control
------------
-Select just HTML rendering and add more selectively::
-
-   dockrun_t3rdf makehtml \                 # html is always being built
-         -c make_singlehtml 1 \             # enable singlehtml
-         -c make_package    1 \             # enable standalone package
-         -c make_latex      1 \             # enable latex + pdf
-         -c make_pdf        1               # enable pdf - on by default
-
-Or select ALL and turn off what you don't need::
-
-   dockrun_t3rdf makeall \                  # html is always being built
-         -c make_singlehtml 0 \             # disable singlehtml
-         -c make_package 0 \                # disable standalone package
-         -c make_pdf 0 \                    # disable pdf
-         -c make_latex 0                    # disable latex + pdf
-
 Specifying folders
 ------------------
 Read through the output of `docker run --rm
@@ -158,10 +139,6 @@ Caching information will be generated automatically and stored in
 `$T3DOCS_RESULT/Cache`. Simply leave that folder untouched to make use of
 the caching mechanism. With caching, for example, a `makehtml` for the TYPO3
 core ChangeLog may take only 15 seconds instead of 20 minutes.
-
-The cache information is built while `html` processing. Other writers like
-`singlehtml` make use of that same caching information and are working rather
-fast. Therefore in general it should not be necessary to turn them off.
 
 
 Caching for ./Documentation files of a repository

--- a/VERSION.txt
+++ b/VERSION.txt
@@ -2,8 +2,6 @@
 v1.6.11-full
 
 
-Uses the toolchain that knows how to render OpenOffice ./doc/manual.sxw.
-
 Keep version number like above in files:
 
 - ./ALL-for-build/Menu/mainmenu.sh

--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,5 +1,5 @@
 
-v1.6.11-full
+v2.0.0
 
 
 Keep version number like above in files:


### PR DESCRIPTION
Remove possibility to render PDF. As we confirmed that PDF rendering will be omitted, there is no need to keep it. Also alias was renamed as there is no need to distinguish between full or html rendering anymore. We still keep makehtml and makeall, in order to allow generation of singlehtml. This also allows visitors to "print" a singlehtml version as PDF.

Also removed further, no longer necessary, dependencies which were there for development purposes. Those can be added while developing the container if necessary.