### PR TITLE
[BUGFIX] fix "pip install" error if /WHEELS empty

### DIFF
--- a/ALL-for-build/Menu/mainmenu.sh
+++ b/ALL-for-build/Menu/mainmenu.sh
@@ -11,7 +11,7 @@ export OUR_IMAGE_SLOGAN=${OUR_IMAGE_SLOGAN:-t3rd_TYPO3_render_documentation}
 
 
 function install-wheels(){
-   find /WHEELS -type f -name *.whl | xargs pip install --upgrade
+   find /WHEELS -type f -name *.whl | xargs --no-run-if-empty pip install --upgrade
 }
 
 


### PR DESCRIPTION
When running with the docker-compose approach https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/RenderingDocs/RenderWithDockerCompose.html on my system the directory /WHEELS is empty.

The "pip install" command gave "ERROR: You must give at least one requirement to install (see "pip help install")" because it was called without arguments.