### PR TITLE
Remove Docker Hub references

### DIFF
--- a/ALL-for-build/Downloads/dockrun_t3rd.bat
+++ b/ALL-for-build/Downloads/dockrun_t3rd.bat
@@ -29,7 +29,7 @@ if not exist %TMP% (
 )
 
 if x%T3DOCS_OURIMAGE%x == xx (
-   set T3DOCS_OURIMAGE=t3docs/render-documentation:latest
+   set T3DOCS_OURIMAGE=ghcr.io/t3docs/render-documentation:latest
 )
 
 if not exist %RESULT% (
@@ -168,7 +168,7 @@ echo    Set the environment variable T3DOCS_OURIMAGE to the container you want
 echo    to use. Afterwards run 'dockrun_t3rd.bat'.
 echo.
 echo    Example:
-echo       set T3DOCS_OURIMAGE=t3docs/render-documentation:develop
+echo       set T3DOCS_OURIMAGE=ghcr.io/t3docs/render-documentation:develop
 echo       %%USERPROFILE%%\dockrun_t3rd.bat
 echo.
 if x%interactive%x == x1x  pause & goto menu

--- a/ALL-for-build/Makedir/sphinxcontrib-plantuml/typo3_styles.iuml
+++ b/ALL-for-build/Makedir/sphinxcontrib-plantuml/typo3_styles.iuml
@@ -3,7 +3,7 @@
 '
 ' Parameters:
 ' Get all available style parameters at the command line of this Docker container:
-' # source <(docker run --rm t3docs/render-documentation show-shell-commands)
+' # source <(docker run --rm ghcr.io/t3docs/render-documentation show-shell-commands)
 ' # dockrun_t3rd /bin/bash
 ' # plantuml -language
 ' => search for "skinparameter"

--- a/ALL-for-build/Menu/mainmenu.sh
+++ b/ALL-for-build/Menu/mainmenu.sh
@@ -4,7 +4,7 @@ source "$HOME/.bashrc"
 source /ALL/Downloads/envvars.sh
 
 # provide defaults
-export OUR_IMAGE=${OUR_IMAGE:-t3docs/render-documentation}
+export OUR_IMAGE=${OUR_IMAGE:-ghcr.io/t3docs/render-documentation}
 export OUR_IMAGE_SHORT=${OUR_IMAGE_SHORT:-t3rd}
 export OUR_IMAGE_SLOGAN=${OUR_IMAGE_SLOGAN:-dockrun_t3rd - TYPO3-render-documentation}
 

--- a/ALL-for-build/Menu/show-howto.sh
+++ b/ALL-for-build/Menu/show-howto.sh
@@ -4,7 +4,7 @@ source "$HOME/.bashrc"
 source /ALL/Downloads/envvars.sh
 
 # provide default
-OUR_IMAGE=${OUR_IMAGE:-t3docs/render-documentation}
+OUR_IMAGE=${OUR_IMAGE:-ghcr.io/t3docs/render-documentation}
 OUR_IMAGE_SHORT=${OUR_IMAGE_SHORT:-t3rd}
 
 cat <<EOT
@@ -27,8 +27,8 @@ Experts: Quickstart for the impatient
 
 Prepare:
 
-   docker pull t3docs/render-documentation
-   source <(docker run --rm t3docs/renderdocumentation show-shell-commands)
+   docker pull ghcr.io/t3docs/render-documentation
+   source <(docker run --rm ghcr.io/t3docs/renderdocumentation show-shell-commands)
 
 Render:
 
@@ -158,7 +158,7 @@ Required and possible volume mappings:
 
 Fetch the docker image (= our executable):
 
-   docker pull t3docs/render-documentation
+   docker pull ghcr.io/t3docs/render-documentation
 
 
 ==================================================

--- a/ALL-for-build/Menu/show-shell-commands.sh
+++ b/ALL-for-build/Menu/show-shell-commands.sh
@@ -12,7 +12,7 @@ OUR_IMAGE_SLOGAN=${OUR_IMAGE_SLOGAN:-"t3rd - TYPO3 render documentation"}
 #2
 OUR_IMAGE_TAG=${OUR_IMAGE_TAG:-"$VERSION"}
 #3
-OUR_IMAGE=${OUR_IMAGE:-"t3docs/render-documentation:$OUR_IMAGE_TAG"}
+OUR_IMAGE=${OUR_IMAGE:-"ghcr.io/t3docs/render-documentation:$OUR_IMAGE_TAG"}
 
 cat <<EOT
 # NOTE

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV \
    LC_ALL=C.UTF-8 \
    LANG=C.UTF-8 \
    HOME="/ALL/userhome" \
-   OUR_IMAGE="t3docs/render-documentation:${OUR_IMAGE_TAG}" \
+   OUR_IMAGE="ghcr.io/t3docs/render-documentation:${OUR_IMAGE_TAG}" \
    OUR_IMAGE_SHORT="${OUR_IMAGE_SHORT}" \
    OUR_IMAGE_VERSION="$OUR_IMAGE_VERSION" \
    PIP_NO_CACHE_DIR=1 \

--- a/Dockerfile.build.sh
+++ b/Dockerfile.build.sh
@@ -24,7 +24,7 @@ if [[ "/ $@ /" =~ " --help " ]]; then
 fi
 
 if ((1)); then
-   docker rmi t3docs/render-documentation:${OUR_IMAGE_TAG}
+   docker rmi ghcr.io/t3docs/render-documentation:${OUR_IMAGE_TAG}
 fi
 
 if ((1)); then
@@ -33,7 +33,7 @@ if ((1)); then
    cmd="$cmd --force-rm=true"
    cmd="$cmd --no-cache=true"
    cmd="$cmd -f ./Dockerfile"
-   cmd="$cmd -t t3docs/render-documentation:${OUR_IMAGE_TAG}"
+   cmd="$cmd -t ghcr.io/t3docs/render-documentation:${OUR_IMAGE_TAG}"
    if [[ ! -z "$OUR_IMAGE_SHORT" ]]; then
      cmd="$cmd --build-arg OUR_IMAGE_SHORT=\"${OUR_IMAGE_SHORT}\""
    fi
@@ -50,12 +50,12 @@ if ((1)); then
    if [ $EXITCODE -eq 0 ]; then
       echo Success!
       echo "You may now run:"
-      echo "   docker run --rm t3docs/render-documentation:${OUR_IMAGE_TAG}"
-      echo "   eval \"\$(docker run --rm t3docs/render-documentation:${OUR_IMAGE_TAG} show-shell-commands)\""
+      echo "   docker run --rm ghcr.io/t3docs/render-documentation:${OUR_IMAGE_TAG}"
+      echo "   eval \"\$(docker run --rm ghcr.io/t3docs/render-documentation:${OUR_IMAGE_TAG} show-shell-commands)\""
    else
       echo Failed
    fi
-   echo "building t3docs/render-documentation:${OUR_IMAGE_TAG} in $BUILD_ELAPSED seconds"
+   echo "building ghcr.io/t3docs/render-documentation:${OUR_IMAGE_TAG} in $BUILD_ELAPSED seconds"
 fi
-echo Looking for image 't3docs:render-documentation:'"${OUR_IMAGE_TAG}"
-docker image ls | awk '$1=="t3docs/render-documentation" && $2=="'${OUR_IMAGE_TAG}'"'
+echo Looking for image 'ghcr.io/t3docs:render-documentation:'"${OUR_IMAGE_TAG}"
+docker image ls | awk '$1=="ghcr.io/t3docs/render-documentation" && $2=="'${OUR_IMAGE_TAG}'"'

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,6 @@ build:  ## Build Docker container. Example: OUR_IMAGE_TAG=local OUR_IMAGE_SHORT=
 
 .PHONY: push_to_ghcr
 push_to_ghcr:  ## [OUR_IMAGE_TAG] ## Example: OUR_IMAGE_TAG=local  make  push_to_ghcr
-	docker tag t3docs/render-documentation:$(OUR_IMAGE_TAG) ghcr.io/t3docs/render-documentation:$(OUR_IMAGE_TAG)
+	docker tag ghcr.io/t3docs/render-documentation:$(OUR_IMAGE_TAG)
 	docker push ghcr.io/t3docs/render-documentation:$(OUR_IMAGE_TAG)
 

--- a/README.rst
+++ b/README.rst
@@ -6,9 +6,8 @@ DRC - Docker Rendering Container
 
    2021-10-20 (tag 'develop')
 
-   The image used to be distributed via Docker hub. However, since Docker hasn't
-   granted a free plan for TYPO3 yet we are currently switching to GitHub's
-   package repository https://ghcr.io/
+   The image used to be distributed via Docker hub. However, since Docker hasn't granted a free plan for TYPO3,
+   we have switched to GitHub's container repository https://ghcr.io/
 
    WAS::
 
@@ -18,16 +17,15 @@ DRC - Docker Rendering Container
    IS NOW::
 
       docker pull ghcr.io/t3docs/render-documentation:develop
-      docker tag ghcr.io/t3docs/render-documentation:develop \
-                         t3docs/render-documentation:develop
-      eval "$(docker run --rm t3docs/render-documentation:develop show-shell-commands)"
+      docker tag ghcr.io/t3docs/render-documentation:develop
+      eval "$(docker run --rm ghcr.io/t3docs/render-documentation:develop show-shell-commands)"
 
 
 What is this?
 =============
 
 Use this repository and `docker build` to build the TYPO3 official Docker image
-`t3docs/render-documentation` for rendering TYPO3 documentation.
+`ghcr.io/t3docs/render-documentation` for rendering TYPO3 documentation.
 
 :Repository:      https://github.com/t3docs/docker-render-documentation
 :Version:         develop (v3.0.dev30)
@@ -51,9 +49,8 @@ host the latest version at the moment and you should not use the usual `docker
 pull t3docs/render-documentation:develop` command. Use `GitHub registry`_
 instead.
 
-:Docker image:    t3docs/render-documentation:develop
-:Docker hub:      https://hub.docker.com/r/t3docs/render-documentation/
-:Docker tags:     https://hub.docker.com/r/t3docs/render-documentation/tags/
+:Docker image:    ghcr.io/t3docs/render-documentation:develop
+:GitHub Container Registry (GHCR):      https://github.com/orgs/t3docs/packages/container/package/render-documentation
 
 
 GitHub registry
@@ -69,12 +66,11 @@ Getting the image from GitHub::
    # pull
    docker pull ghcr.io/t3docs/render-documentation:develop
 
-   # Assign our usual tag `t3docs/render-documentation:develop`
-   docker tag ghcr.io/t3docs/render-documentation:develop \
-                      t3docs/render-documentation:develop
+   # Assign our usual tag `ghcr.io/t3docs/render-documentation:develop`
+   docker tag ghcr.io/t3docs/render-documentation:develop
 
    # Define the helper function `dockrun_t3rd`
-    eval "$(docker run --rm t3docs/render-documentation:develop show-shell-commands)"
+    eval "$(docker run --rm ghcr.io/t3docs/render-documentation:develop show-shell-commands)"
 
 
 Using the image::
@@ -82,11 +78,10 @@ Using the image::
    # some (educational) example calls
    #
    docker run --rm ghcr.io/t3docs/render-documentation:develop
-   docker run --rm t3docs/render-documentation:develop
-   docker run --rm t3docs/render-documentation:develop --help
+   docker run --rm ghcr.io/t3docs/render-documentation:develop --help
    #
    # define 'dockrun_t3rd'
-   eval "$(docker run --rm t3docs/render-documentation:develop show-shell-commands)"
+   eval "$(docker run --rm ghcr.io/t3docs/render-documentation:develop show-shell-commands)"
    dockrun_t3rd
    dockrun_t3rd --help
    T3DOCS_DEBUG=1  dockrun_t3rd


### PR DESCRIPTION
The Docker Hub was removed, so the GHCR image is the only image that can be used.
This PR removes all references to the Docker Hub image from source code and documentation to reflect the current state.

I'd like to see a merge into master and stable image tags, so we can fix our pipelines which have been failing since the Docker Hub image was deleted.

Relates to: #129