### PR TITLE
Fix image path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENV \
    LC_ALL=C.UTF-8 \
    LANG=C.UTF-8 \
    HOME="/ALL/userhome" \
-   OUR_IMAGE="t3docs/render-documentation:${OUR_IMAGE_TAG}" \
+   OUR_IMAGE="ghcr.io/t3docs/render-documentation:${OUR_IMAGE_TAG}" \
    OUR_IMAGE_SHORT="${OUR_IMAGE_SHORT}" \
    OUR_IMAGE_VERSION="$OUR_IMAGE_VERSION" \
    PIP_NO_CACHE_DIR=1 \


### PR DESCRIPTION
The Dockerfile references an old image path `t3docs/render-documentation`. Since the image is now hosted on ghcr.io this reference does no longer work when following the [How to render documentation](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/RenderingDocs/Index.html) guide and executing

```shell
dockrun_t3rd makehtml
```

The environment variable is used in the `show-shell-commands` script which in turn results in a wrong image being referenced by the registered `dockrun_t3rd` function.

I think just changing this environment variable would enable someone to actually follow the guide again.